### PR TITLE
Add soft K means

### DIFF
--- a/ml.q
+++ b/ml.q
@@ -258,7 +258,7 @@ cgroup:{[df;X;C]value group imin f2nd[df X] C}
 / matri(X) to the nearest (C)entroid and then uses the (c)entroid (f)unction
 / to update the centroid location.
 lloyd:{[df;cf;X;C]cf X@\: cgroup[df;X;C]}
-/ uses (r)esponsibility (f)unction David Mackay's Information Theory... pg 289
+/ use (r)esponsibility (f)unction David Mackay's Information Theory..(pg289)
 lloyds:{[df;cf;rf;X;C] cf[rf .ml.f2nd[df X] C;X]} /soft assignment 
 
 kmeans:lloyd[edist2;avg'']      / k-means
@@ -266,9 +266,11 @@ kmedians:lloyd[mdist;med'']     / k-medians
 khmeans:lloyd[edist2;hmean'']   / k harmonic means
 skmeans:lloyd[cosdist;normalize (avg'')::] / spherical k-means
 
-kmeanss:lloyds[edist2;wavg\:/:;{x=\:min x}] /k-means using loyd with rf
-/ kmeansoft1 David Mackay (b)eta stiffness param
-kmeans1:{[b;X] lloyds[.ml.edist2;wavg\:/:;{p%\:sum p:exp x*y}[neg b];X]} 
+kmeanss:lloyds[edist2;wavg\:/:;dax[=;min]] /k-means using loyd with rf
+/ kmeansoft v1 David Mackay (b)eta stiffness param 
+/ sigma or radius of cluster is 1%sqrt b
+smin:prb exp@* /soft min
+kmeansmin:{[b;X] lloyds[edist2;wavg\:/:;smin neg b;X]} 
 
 / using (d)istance (f)unction, find the medoid in matri(X)
 medoid:{[df;X]X@\:imin f2nd[sum df[X]::] X}

--- a/ml.q
+++ b/ml.q
@@ -269,7 +269,7 @@ skmeans:lloyd[cosdist;normalize (avg'')::] / spherical k-means
 kmeanss:lloyds[edist2;wavg\:/:;dax[=;min]] /k-means using loyd with rf
 / kmeansoft v1 David Mackay (b)eta stiffness param 
 / sigma or radius of cluster is 1%sqrt b
-kmeansmin:{[b;X] lloyds[edist2;wavg\:/:;softmax neg[b]*;X]} 
+kmeanssmax:{[b;X] lloyds[edist2;wavg\:/:;softmax neg[b]*;X]} 
 
 / using (d)istance (f)unction, find the medoid in matri(X)
 medoid:{[df;X]X@\:imin f2nd[sum df[X]::] X}

--- a/ml.q
+++ b/ml.q
@@ -124,6 +124,7 @@ zscore:fxx zscoref:{daxf[%;nsdev;x] demeanf[x]::}
 minmax:fxx minmaxf:{daxf[%;{max[x]-min x};x] daxf[-;min;x]::}
 / convert densities into probabilities
 prb:dax[%;sum]
+ismin:dax[=;min]
 
 / given (g)rouped dictionary, compute the odds
 odds:{[g]prb count each g}
@@ -266,7 +267,7 @@ kmedians:lloyd[mdist;med'']     / k-medians
 khmeans:lloyd[edist2;hmean'']   / k harmonic means
 skmeans:lloyd[cosdist;normalize (avg'')::] / spherical k-means
 
-kmeanss:lloyds[edist2;wavg\:/:;dax[=;min]] /k-means using loyd with rf
+kmeanss:lloyds[edist2;wavg\:/:;ismin] /k-means using loyd with rf
 / kmeansoft v1 David Mackay (b)eta stiffness param 
 / sigma or radius of cluster is 1%sqrt b
 kmeanssmax:{[b;X] lloyds[edist2;wavg\:/:;softmax neg[b]*;X]} 

--- a/ml.q
+++ b/ml.q
@@ -258,11 +258,17 @@ cgroup:{[df;X;C]value group imin f2nd[df X] C}
 / matri(X) to the nearest (C)entroid and then uses the (c)entroid (f)unction
 / to update the centroid location.
 lloyd:{[df;cf;X;C]cf X@\: cgroup[df;X;C]}
+/ uses (r)esponsibility (f)unction David Mackay's Information Theory... pg 289
+lloyds:{[df;cf;rf;X;C] cf[rf .ml.f2nd[df X] C;X]} /soft assignment 
 
 kmeans:lloyd[edist2;avg'']      / k-means
 kmedians:lloyd[mdist;med'']     / k-medians
 khmeans:lloyd[edist2;hmean'']   / k harmonic means
 skmeans:lloyd[cosdist;normalize (avg'')::] / spherical k-means
+
+kmeanss:lloyds[edist2;wavg\:/:;{x=\:min x}] /k-means using loyd with rf
+/ kmeansoft1 David Mackay (b)eta stiffness param
+kmeans1:{[b;X] lloyds[.ml.edist2;wavg\:/:;{p%\:sum p:exp x*y}[neg b];X]} 
 
 / using (d)istance (f)unction, find the medoid in matri(X)
 medoid:{[df;X]X@\:imin f2nd[sum df[X]::] X}

--- a/ml.q
+++ b/ml.q
@@ -269,8 +269,7 @@ skmeans:lloyd[cosdist;normalize (avg'')::] / spherical k-means
 kmeanss:lloyds[edist2;wavg\:/:;dax[=;min]] /k-means using loyd with rf
 / kmeansoft v1 David Mackay (b)eta stiffness param 
 / sigma or radius of cluster is 1%sqrt b
-smin:prb exp@* /soft min
-kmeansmin:{[b;X] lloyds[edist2;wavg\:/:;smin neg b;X]} 
+kmeansmin:{[b;X] lloyds[edist2;wavg\:/:;softmax neg[b]*;X]} 
 
 / using (d)istance (f)unction, find the medoid in matri(X)
 medoid:{[df;X]X@\:imin f2nd[sum df[X]::] X}


### PR DESCRIPTION
http://www.inference.org.uk/mackay/itprnn/ps/284.292.pdf
http://www.inference.org.uk/mackay/itprnn/code/kmeans/

Example code:
```q
\l funq.q
\l iris.q
X:iris.X
\S -314159i
c:.ml.forgy[3] X
/ 
these all return the same answer (within epsilon 5e-5)
5.006    3.428    1.462    0.246   
5.901613 2.748387 4.393548 1.433871
6.85     3.073684 5.742105 2.071053
\
asc flip .ml.kmeans[X] over c
asc flip .ml.kmeanss[X] over c
asc flip .ml.kmeans1[100;X] over c1
```