### PR TITLE
Gutenberg file naming changed

### DIFF
--- a/emma.q
+++ b/emma.q
@@ -1,6 +1,6 @@
 / emma
 emma.f:"158.txt"
-emma.b:"http://www.gutenberg.org/files/158/"
+emma.b:"https://www.gutenberg.org/files/158/old/"
 -1"[down]loading emma text";
 .ut.download[emma.b;;"";""] emma.f;
 emma.txt:{x where not x like "VOLUME*"} read0 `$emma.f

--- a/mansfield.q
+++ b/mansfield.q
@@ -1,6 +1,6 @@
 / mansfield park
 mansfield.f:"141.txt"
-mansfield.b:"http://www.gutenberg.org/files/141/"
+mansfield.b:"https://www.gutenberg.org/files/141/old/"
 -1"[down]loading mansfield park text";
 .ut.download[mansfield.b;;"";""] mansfield.f;
 mansfield.txt:read0 `$mansfield.f

--- a/northanger.q
+++ b/northanger.q
@@ -1,6 +1,6 @@
 / northanger abbey
-northanger.f:"121.txt"
-northanger.b:"http://www.gutenberg.org/files/121/"
+northanger.f:"20080515-121.txt"
+northanger.b:"https://www.gutenberg.org/files/121/old/"
 -1"[down]loading northanger abbey text";
 .ut.download[northanger.b;;"";""] northanger.f;
 northanger.txt:read0 `$northanger.f

--- a/pandp.q
+++ b/pandp.q
@@ -1,8 +1,7 @@
-/ pride and prejudice
 pandp.f:"1342-0.txt"
-pandp.b:"http://www.gutenberg.org/files/1342/"
+pandp.b:"https://www.gutenberg.org/files/1342/"
 -1"[down]loading pride and prejudice text";
 .ut.download[pandp.b;;"";""] pandp.f;
 pandp.txt:read0 `$pandp.f
-pandp.chapters:1_"Chapter" vs "\n" sv  6_'166_-373_ pandp.txt
-pandp.s:{(2+first x ss"\n\n")_x} each .ut.sr[.ut.ua] peach pandp.chapters
+pandp.chapters:1_"\nChapter " vs "\n" sv  35_-373_ pandp.txt
+pandp.s:{first[x ss"\n\n"]_x} each pandp.chapters

--- a/persuasion.q
+++ b/persuasion.q
@@ -1,6 +1,6 @@
 / persuasion
 persuasion.f:"105.txt"
-persuasion.b:"http://www.gutenberg.org/files/105/"
+persuasion.b:"https://www.gutenberg.org/files/105/"
 -1"[down]loading persuasion text";
 .ut.download[persuasion.b;;"";""] persuasion.f;
 persuasion.txt:read0 `$persuasion.f

--- a/sands.q
+++ b/sands.q
@@ -1,6 +1,6 @@
 / sense and sensibility
 sands.f:"161.txt"
-sands.b:"http://www.gutenberg.org/files/161/"
+sands.b:"https://www.gutenberg.org/files/161/old/"
 -1"[down]loading sense and sensibility text";
 .ut.download[sands.b;;"";""] sands.f;
 sands.txt:read0 `$sands.f


### PR DESCRIPTION
I believe the files changed a little bit on the Gutenberg website. 
The ASCII versions are now (mostly) found under an "old" folder. 
Also, this might be due to how my internet is set-up locally, but downloading via http creates empty files, hence I changed to https.

For the Pride and Prejudice book I couldn't find the same file, This one seems to be in UTF-8. Nonetheless everything seems to be fine with the pushed code. 

Best,